### PR TITLE
use remotes for suggested install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ cell) and `start_date` and `end_date`.
 Install the development version from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("geomarker-io/addNarrData")
+# install.packages("remotes")
+remotes::install_github("geomarker-io/addNarrData")
 ```
 
 ## Example


### PR DESCRIPTION
I've seen this as "best practice" and makes sense since `remotes` is much more lighweight.